### PR TITLE
Bump `uvloop` from `>=0.14` to `>=0.15.2`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -643,4 +643,4 @@ uvloop = ["uvloop"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "1a4f5c52f5472ecf445447134f0dec7af5f9696ea92b584253f750d9f23de15f"
+content-hash = "2066436f8b3b04d7433b6c73dbb9a92c5f67b2250d2ebaba21bafe11f5bda190"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ python = "^3.8"
 typing_extensions = {version = "^4.1", python = "<3.11"}
 
 [tool.poetry.dependencies.uvloop]
-version = ">=0.14,<1.0"
+version = ">=0.15.2,<1.0"
 optional = true
 markers = 'sys_platform != "win32"'
 python = "<3.13"


### PR DESCRIPTION
for correct typing annotations and python dependency requirements