### PR TITLE
deterministic `@main` return type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.9"
-dependencies = [
-  "typing-extensions>=4.1; python_version < '3.11'",
-]
+dependencies = []
 
 [project.urls]
 Repository = "https://github.com/jorenham/mainpy"
@@ -66,7 +64,6 @@ exclude = [
 
 [tool.uv]
 dev-dependencies = [
-  "typing-extensions",
   "uvloop; sys_platform != 'win32'",
 
   "basedpyright>=1.17.5,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,14 +104,7 @@ stubPath = "."
 typeCheckingMode = "all"
 venv = ".venv"
 venvPath = "."
-
-reportAny = false
-reportInvalidCast = false
-reportUnusedCallResult = false
-# this appears to be broken since pyright 1.1.359
-reportUntypedFunctionDecorator = false
-# because of `sys.version_info()` conditionals
-reportUnreachable = false
+reportUnreachable = false  # unavoidable with `sys.version_info` conditionals
 
 
 [tool.repo-review]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ exclude = [
 
 [tool.uv]
 dev-dependencies = [
+  "typing_extensions>=4.12.2",
   "uvloop; sys_platform != 'win32'",
 
   "basedpyright>=1.17.5,<2",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,12 +8,14 @@ import pytest
 PY_SYNC = """
 import mainpy
 
+result = [None]
+
 @mainpy.main
 def sync_main():
     print({!r})
-    return 42
+    result[0] = 42
 
-assert sync_main == 42
+assert result[0] == 42
 """.strip()
 
 # language=python
@@ -21,12 +23,14 @@ PY_ASYNC = """
 import asyncio
 import mainpy
 
+result = [None]
+
 @mainpy.main
 async def async_main():
     print({!r})
-    return await asyncio.sleep(1e-6, 42)
+    result[0] = await asyncio.sleep(1e-6, 42)
 
-assert async_main == 42
+assert result[0] == 42
 """.strip()
 
 

--- a/tests/test_mainpy.py
+++ b/tests/test_mainpy.py
@@ -49,30 +49,39 @@ def test_not_main(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_sync(monkeypatch: pytest.MonkeyPatch):
+    result: list[object] = [None]
+
     @mp.main(is_async=False)
     @_patch_module(monkeypatch, '__main__')
     def app():
-        return 'spam'
+        result[0] = 'spam'
 
-    assert app == 'spam'
+    assert result[0] == 'spam'
+    assert callable(app)
 
 
 def test_sync_implicit(monkeypatch: pytest.MonkeyPatch):
+    result: list[object] = [None]
+
     @mp.main
     @_patch_module(monkeypatch, '__main__')
     def app():
-        return 'spam'
+        result[0] = 'spam'
 
-    assert app == 'spam'
+    assert result[0] == 'spam'
+    assert callable(app)
 
 
 def test_async(monkeypatch: pytest.MonkeyPatch):
+    result: list[object] = [None]
+
     @mp.main(is_async=True, use_uvloop=False)
     @_patch_module(monkeypatch, '__main__')
     async def app():
-        return await asyncio.sleep(0, 'spam')
+        result[0] = await asyncio.sleep(0, 'spam')
 
-    assert app == 'spam'
+    assert result[0] == 'spam'
+    assert callable(app)
     assert isinstance(
         asyncio.get_event_loop_policy(),
         asyncio.DefaultEventLoopPolicy,
@@ -80,12 +89,15 @@ def test_async(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_async_implicit(no_uvloop: None, monkeypatch: pytest.MonkeyPatch):  # pyright: ignore[reportUnusedParameter]
+    result: list[object] = [None]
+
     @mp.main
     @_patch_module(monkeypatch, '__main__')
     async def app():
-        return await asyncio.sleep(0, 'spam')
+        result[0] = await asyncio.sleep(0, 'spam')
 
-    assert app == 'spam'
+    assert result[0] == 'spam'
+    assert callable(app)
     assert isinstance(
         asyncio.get_event_loop_policy(),
         asyncio.DefaultEventLoopPolicy,
@@ -93,19 +105,22 @@ def test_async_implicit(no_uvloop: None, monkeypatch: pytest.MonkeyPatch):  # py
 
 
 def test_async_implicit_uvloop(monkeypatch: pytest.MonkeyPatch):
+    result: list[object] = [None]
+
     @mp.main
     @_patch_module(monkeypatch, '__main__')
     async def loop_module():
         await asyncio.sleep(0)
         loop = asyncio.get_running_loop()
-        return loop.__module__.split('.')[0]
+        result[0] = loop.__module__.split('.')[0]
 
-    assert loop_module
-    assert isinstance(loop_module, str)
+    assert result[0]
+    assert isinstance(result[0], str)
+    assert callable(loop_module)
 
     if importlib.util.find_spec('uvloop') is None:
         assert not mp._infer_uvloop()
-        assert loop_module == 'asyncio'
+        assert result[0] == 'asyncio'
     else:
         assert mp._infer_uvloop()
-        assert loop_module == 'uvloop'
+        assert result[0] == 'uvloop'

--- a/uv.lock
+++ b/uv.lock
@@ -138,6 +138,7 @@ dev = [
     { name = "ruff" },
     { name = "sp-repo-review", extra = ["cli"], marker = "python_full_version >= '3.10'" },
     { name = "tox" },
+    { name = "typing-extensions" },
     { name = "uvloop", marker = "sys_platform != 'win32'" },
 ]
 
@@ -153,6 +154,7 @@ dev = [
     { name = "ruff", specifier = ">=0.6.5,<0.7" },
     { name = "sp-repo-review", extras = ["cli"], marker = "python_full_version >= '3.10'", specifier = ">=2024.8.19" },
     { name = "tox", specifier = ">=4.20.0" },
+    { name = "typing-extensions", specifier = ">=4.12.2" },
     { name = "uvloop", marker = "sys_platform != 'win32'" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -123,9 +123,6 @@ wheels = [
 name = "mainpy"
 version = "1.4.1.dev0"
 source = { editable = "." }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
 
 [package.optional-dependencies]
 uvloop = [
@@ -141,15 +138,11 @@ dev = [
     { name = "ruff" },
     { name = "sp-repo-review", extra = ["cli"], marker = "python_full_version >= '3.10'" },
     { name = "tox" },
-    { name = "typing-extensions" },
     { name = "uvloop", marker = "sys_platform != 'win32'" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.1" },
-    { name = "uvloop", marker = "python_full_version < '3.13' and sys_platform != 'win32' and extra == 'uvloop'", specifier = ">=0.15.2,<1" },
-]
+requires-dist = [{ name = "uvloop", marker = "python_full_version < '3.13' and sys_platform != 'win32' and extra == 'uvloop'", specifier = ">=0.15.2,<1" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -160,7 +153,6 @@ dev = [
     { name = "ruff", specifier = ">=0.6.5,<0.7" },
     { name = "sp-repo-review", extras = ["cli"], marker = "python_full_version >= '3.10'", specifier = ">=2024.8.19" },
     { name = "tox", specifier = ">=4.20.0" },
-    { name = "typing-extensions" },
     { name = "uvloop", marker = "sys_platform != 'win32'" },
 ]
 


### PR DESCRIPTION
fixes #46

Instead of returning an over-engineered function wrapper, I decided to follow the advice of @KotlinIsland and simply return the original function directly, as the result of the main function doesn't matter anyway.

As a consequence of the cleaner code, the `typing_extensions` dependency isn't needed anymore, so I removed it from the required dependencies for `python < 3.11`.